### PR TITLE
[Fix] Support virtio-vdpa device

### DIFF
--- a/.github/workflows/static-scan.yml
+++ b/.github/workflows/static-scan.yml
@@ -5,12 +5,17 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.18.x
       - uses: actions/checkout@v2
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3.2.0
         with:
-          # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.45
+          version: v1.48
+          skip-pkg-cache: true
+          skip-build-cache: true
+          args: "--out-${NO_FUTURE}format colored-line-number"
   shellcheck:
     name: Shellcheck
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ export GO111MODULE=on
 # Docker
 IMAGEDIR=$(BASE)/images
 DOCKERFILE=$(CURDIR)/Dockerfile
-TAG=ghcr.io/MangoBoost/sriov-cni
+TAG=ghcr.io/mangoboost/sriov-cni
 # Accept proxy settings for docker 
 DOCKERARGS=
 ifdef HTTP_PROXY

--- a/cmd/sriov/main.go
+++ b/cmd/sriov/main.go
@@ -5,15 +5,15 @@ import (
 	"fmt"
 	"runtime"
 
+	"github.com/MangoBoost/sriov-cni/pkg/config"
+	"github.com/MangoBoost/sriov-cni/pkg/sriov"
+	"github.com/MangoBoost/sriov-cni/pkg/utils"
 	"github.com/containernetworking/cni/pkg/skel"
 	"github.com/containernetworking/cni/pkg/types"
 	current "github.com/containernetworking/cni/pkg/types/100"
 	"github.com/containernetworking/cni/pkg/version"
 	"github.com/containernetworking/plugins/pkg/ipam"
 	"github.com/containernetworking/plugins/pkg/ns"
-	"github.com/MangoBoost/sriov-cni/pkg/config"
-	"github.com/MangoBoost/sriov-cni/pkg/sriov"
-	"github.com/MangoBoost/sriov-cni/pkg/utils"
 	"github.com/vishvananda/netlink"
 )
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -6,9 +6,9 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/containernetworking/cni/pkg/skel"
 	sriovtypes "github.com/MangoBoost/sriov-cni/pkg/types"
 	"github.com/MangoBoost/sriov-cni/pkg/utils"
+	"github.com/containernetworking/cni/pkg/skel"
 )
 
 var (

--- a/pkg/sriov/sriov_test.go
+++ b/pkg/sriov/sriov_test.go
@@ -3,9 +3,9 @@ package sriov
 import (
 	"net"
 
+	sriovtypes "github.com/MangoBoost/sriov-cni/pkg/types"
 	"github.com/containernetworking/plugins/pkg/ns"
 	"github.com/containernetworking/plugins/pkg/testutils"
-	sriovtypes "github.com/MangoBoost/sriov-cni/pkg/types"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/stretchr/testify/mock"


### PR DESCRIPTION
This patch supports a virtio-vdpa device by attaching
its virtio netdevice directly to the pod.

Signed-off-by: Dongju Chae <dongju.chae@mangoboost.io>